### PR TITLE
add history-contributors-feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6465,6 +6465,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-dom": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.9.tgz",
+      "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
+      "peer": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-is": {
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
@@ -7419,6 +7428,36 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+    },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/babel-jsx-utils": {
       "version": "1.1.0",
@@ -22320,6 +22359,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
@@ -25771,7 +25823,8 @@
     "@coreui/react": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@coreui/react/-/react-4.4.0.tgz",
-      "integrity": "sha512-72ZKArQQCMknqaE5AHDdOGy/kTl7xDK/I8reuWX6uTHLRD3Rz85pIA5IUzHafLIOlte8Sci0fdWYG8UshpXQyQ=="
+      "integrity": "sha512-72ZKArQQCMknqaE5AHDdOGy/kTl7xDK/I8reuWX6uTHLRD3Rz85pIA5IUzHafLIOlte8Sci0fdWYG8UshpXQyQ==",
+      "requires": {}
     },
     "@emotion/babel-plugin": {
       "version": "11.10.2",
@@ -25903,7 +25956,8 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.2.0",
@@ -27113,7 +27167,8 @@
     "@mui/types": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA=="
+      "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==",
+      "requires": {}
     },
     "@mui/utils": {
       "version": "5.10.6",
@@ -27333,7 +27388,8 @@
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "6.7.0",
@@ -28274,6 +28330,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-dom": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.9.tgz",
+      "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
+      "peer": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-is": {
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
@@ -28647,12 +28712,14 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "address": {
       "version": "1.1.2",
@@ -28682,7 +28749,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "anser": {
       "version": "2.1.1",
@@ -28973,6 +29041,28 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+    },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "peer": true
+        }
+      }
     },
     "babel-jsx-utils": {
       "version": "1.1.0",
@@ -29331,7 +29421,8 @@
     "bootstrap": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.1.tgz",
-      "integrity": "sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA=="
+      "integrity": "sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==",
+      "requires": {}
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -30349,7 +30440,8 @@
     "css-declaration-sorter": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
-      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og=="
+      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
+      "requires": {}
     },
     "css-loader": {
       "version": "5.2.7",
@@ -30536,7 +30628,8 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -31502,7 +31595,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -32737,7 +32831,8 @@
     "gatsby-material-ui-components": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-material-ui-components/-/gatsby-material-ui-components-5.3.0.tgz",
-      "integrity": "sha512-yBIEZfqIi4kmENjZNH19iYMsTmCMhnyizwBG5ea7ajc4/virFS/6b/tsddJ6bFHHaOKZwsoCoyIQuwmr/dOWrg=="
+      "integrity": "sha512-yBIEZfqIi4kmENjZNH19iYMsTmCMhnyizwBG5ea7ajc4/virFS/6b/tsddJ6bFHHaOKZwsoCoyIQuwmr/dOWrg==",
+      "requires": {}
     },
     "gatsby-page-utils": {
       "version": "2.21.0",
@@ -33048,7 +33143,8 @@
     "gatsby-script": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-1.6.0.tgz",
-      "integrity": "sha512-I+dvuVnJtGJmII/f4UgM0VYHSbgnj2K/T9hVlgf9Bv5PkOqHIcoiq4bQO3s+LQwX/OCeCHWc2ffCZjLR3uPhSw=="
+      "integrity": "sha512-I+dvuVnJtGJmII/f4UgM0VYHSbgnj2K/T9hVlgf9Bv5PkOqHIcoiq4bQO3s+LQwX/OCeCHWc2ffCZjLR3uPhSw==",
+      "requires": {}
     },
     "gatsby-sharp": {
       "version": "0.15.0",
@@ -33544,7 +33640,8 @@
     "gatsby-theme-material-ui-top-layout": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/gatsby-theme-material-ui-top-layout/-/gatsby-theme-material-ui-top-layout-5.2.0.tgz",
-      "integrity": "sha512-KmrLJuZu1zMTqrYaG9/UcRQrLm8WFn08tA6vGPZdTjMU6WhNa6LGd34n/tT9x7Te9Qu4HHwDu8qN1j/zw3/kTA=="
+      "integrity": "sha512-KmrLJuZu1zMTqrYaG9/UcRQrLm8WFn08tA6vGPZdTjMU6WhNa6LGd34n/tT9x7Te9Qu4HHwDu8qN1j/zw3/kTA==",
+      "requires": {}
     },
     "gatsby-transformer-remark": {
       "version": "5.21.0",
@@ -34011,12 +34108,14 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+      "requires": {}
     },
     "graphql-ws": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.9.0.tgz",
-      "integrity": "sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag=="
+      "integrity": "sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==",
+      "requires": {}
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -34388,7 +34487,8 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -34982,7 +35082,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "iterall": {
       "version": "1.3.0",
@@ -35837,7 +35938,8 @@
     "meros": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/meros/-/meros-1.1.4.tgz",
-      "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ=="
+      "integrity": "sha512-E9ZXfK9iQfG9s73ars9qvvvbSIkJZF5yOo9j4tcwM5tN8mUKfj/EKN5PzOr3ZH0y5wL7dLAHw3RVEfpQV9Q7VQ==",
+      "requires": {}
     },
     "methods": {
       "version": "1.1.2",
@@ -37234,27 +37336,32 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "requires": {}
     },
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
+      "requires": {}
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -37333,7 +37440,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -37364,7 +37472,8 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -38085,7 +38194,8 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -40080,6 +40190,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "peer": true
+    },
     "ua-parser-js": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
@@ -40816,7 +40932,8 @@
     "ws": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -90,6 +90,13 @@ const NavBar = () => {
           >
             Get Started
           </Nav.Link>
+          <Nav.Link
+            className="navlink"
+            variant="outline-dark"
+            href="/contributors"
+          >
+            Contributors
+          </Nav.Link>
           <Search>
             <form onSubmit={handleSubmit}>
               <SearchIconWrapper>

--- a/src/pages/contributors.js
+++ b/src/pages/contributors.js
@@ -1,0 +1,218 @@
+import {
+  Avatar,
+  CircularProgress,
+  Divider,
+  Link,
+  List,
+  ListItem,
+  ListItemAvatar,
+  Pagination,
+  Stack,
+  Typography,
+} from "@mui/material"
+import { Box } from "@mui/system"
+import React, { useState } from "react"
+import { useEffect } from "react"
+import NavBar from "../Components/NavBar"
+
+const Contributors = () => {
+  const [commits, setCommits] = useState("")
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pages, setPages] = useState(1)
+  const [rows, setRows] = useState(10)
+  const [descending, setDesending] = useState(true)
+  const [sortByDate, setSortByDate] = useState(true)
+  const reversedCommits = !commits ? "" : [...commits].reverse()
+  const alphabeticalCommits = [...commits].sort(function (a, b) {
+    var textA = a.name.toUpperCase()
+    var textB = b.name.toUpperCase()
+    return textA < textB ? -1 : textA > textB ? 1 : 0
+  })
+  const reversedAlphabeticalCommits = [...alphabeticalCommits].reverse()
+
+  const getUsers = async () => {
+    const url = "https://api.github.com/repos/thoth-tech/handbook/commits"
+    const response = await fetch(url)
+    const result = await response.json()
+
+    const commitList = result.map(item => {
+      const date = new Date(item.commit.author.date)
+
+      return {
+        id: item.sha,
+        name: item.commit.author.name,
+        date: date.toLocaleString(),
+        message: item.commit.message,
+        email: item.author.html_url,
+        username: item.author.login,
+        avatar: item.author.avatar_url,
+        commit: item.html_url,
+      }
+    })
+    setCommits(commitList)
+    setPages(Math.ceil(commitList.length / rows))
+  }
+
+  const movePage = (event, page) => {
+    setCurrentPage(page)
+  }
+
+  const changeRows = event => {
+    const value = +event.target.value
+    setRows(value)
+    setPages(Math.ceil(commits.length / value))
+  }
+
+  const changeOrder = () => {
+    setDesending(prevValue => !prevValue)
+  }
+
+  const changeSort = () => {
+    setSortByDate(prevValue => !prevValue)
+  }
+
+  const loadingAnimation = (
+    <Box
+      sx={{
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        position: "absolute",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <CircularProgress />
+    </Box>
+  )
+
+  const commitsContent = !commits ? (
+    loadingAnimation
+  ) : (
+    <List
+      sx={{
+        width: "100%",
+        maxWidth: "900px",
+        bgcolor: "background.paper",
+        justifyContent: "center",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {(descending && sortByDate
+        ? commits
+        : !descending && sortByDate
+        ? reversedCommits
+        : !descending && !sortByDate
+        ? alphabeticalCommits
+        : reversedAlphabeticalCommits
+      ).map((item, index) => {
+        if (currentPage * rows > index && currentPage * rows - rows <= index)
+          return (
+            <Box key={item.id}>
+              <ListItem alignItems="flex-start">
+                <ListItemAvatar>
+                  <Avatar alt="avatar" src={item.avatar} />
+                </ListItemAvatar>
+                <Box>
+                  <Typography color="text.primary" variant="subtitle1">
+                    {item.name} (
+                    <Link underline="hover" href={item.email}>
+                      {item.username}
+                    </Link>
+                    )
+                  </Typography>
+
+                  <Typography color="text.secondary" variant="body2">
+                    Date: {item.date}
+                    <br />
+                    Message: {item.message}
+                    <br />
+                    Commit:{" "}
+                    <Link underline="hover" href={item.commit}>
+                      {item.commit}
+                    </Link>
+                  </Typography>
+                </Box>
+              </ListItem>
+              <Divider variant="inset" component="li" />
+            </Box>
+          )
+      })}
+    </List>
+  )
+
+  const rowNumber = (
+    <form onChange={changeRows}>
+      <span>{"Rows: "} </span>
+      <select defaultValue="10">
+        <option value="10">10</option>
+        <option value="25">25</option>
+        <option value="50">50</option>
+      </select>
+    </form>
+  )
+
+  const listOrder = (
+    <form onChange={changeOrder}>
+      <span>{"Order: "} </span>
+      <select defaultValue={true}>
+        <option value={true}>Desc ⬇</option>
+        <option value={false}>Asc ⬆</option>
+      </select>
+    </form>
+  )
+
+  const sortBy = (
+    <form onChange={changeSort}>
+      <span>{"Sort by: "} </span>
+      <select defaultValue={true}>
+        <option value={true}>Date</option>
+        <option value={false}>Name</option>
+      </select>
+    </form>
+  )
+
+  useEffect(() => {
+    if (!commits) {
+      getUsers()
+    }
+    // eslint-disable-next-line
+  }, [])
+
+  return (
+    <>
+      <NavBar />
+      <Box display="flex" justifyContent="center" sx={{ my: 2 }}>
+        {commitsContent}
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        sx={{ my: 2 }}
+      >
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={{ xs: 1, sm: 2, md: 4 }}
+          divider={
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{ borderColor: "black" }}
+            />
+          }
+        >
+          <Pagination count={pages} onChange={movePage} page={currentPage} />
+          {rowNumber}
+          {listOrder}
+          {sortBy}
+        </Stack>
+      </Box>
+    </>
+  )
+}
+
+export default Contributors


### PR DESCRIPTION
The history contribution information page can be found by clicking the Contributors within the Navbar.
<img src="https://user-images.githubusercontent.com/87536767/204682825-3ea23aa7-3928-4e4a-a91a-b4c4429e1793.png" width="50%" height="50%">

The history contribution page consists of all contributor information including their Github avatar, profile link, commit link, date, and message.
<img src="https://user-images.githubusercontent.com/87536767/204683227-328b92e2-2f0e-42e6-8ef2-b9b588730bc7.png" width="50%" height="50%">

Users can sort the list by name, date, which can be in descending or ascending order. The numbers of rows can also be adjusted depending on the users preference.
<img src="https://user-images.githubusercontent.com/87536767/204683366-3271dbc2-37c6-402b-9639-fceeb6f96abe.png" width="50%" height="50%">